### PR TITLE
Improve TopicUpdater's uptime to include %daysonline%

### DIFF
--- a/src/main/java/com/magitechserver/magibridge/config/categories/Messages.java
+++ b/src/main/java/com/magitechserver/magibridge/config/categories/Messages.java
@@ -39,8 +39,8 @@ public class Messages {
     @Setting(value = "channel-topic-offline", comment = "Message that will be set in the main discord channel topic when the server goes offline")
     public String OFFLINE_TOPIC = "The server is currently offline!";
     @Setting(value = "channel-topic-message", comment = "Message that will be set in the main discord channel topic every X seconds\n" +
-            "Supports %tps%, %players%, %maxplayers%, %hoursonline% and %minutesonline%")
-    public String TOPIC_MESSAGE = "%players%/%maxplayers% players online | TPS: %tps% | Server online for %hoursonline% hours or %minutesonline% minutes!";
+            "Supports %tps%, %players%, %maxplayers%, %daysonline%, %hoursonline% and %minutesonline%")
+    public String TOPIC_MESSAGE = "%players%/%maxplayers% players online | TPS: %tps% | Server online for %daysonline% days,  %hoursonline% hours and %minutesonline% minutes!";
     @Setting(value = "death-message", comment = "Message that will be sent to the main discord channel when a player dies")
     public String DEATH_MESSAGE = "**Bad day for %player%: %deathmessage%**";
     @Setting(value = "advancement-message", comment = "Message that will be sent to the main discord channel when a player receives an advancement\n" +

--- a/src/main/java/com/magitechserver/magibridge/util/TopicUpdater.java
+++ b/src/main/java/com/magitechserver/magibridge/util/TopicUpdater.java
@@ -22,8 +22,9 @@ public class TopicUpdater extends Thread {
                         .replace("%players%", Integer.valueOf(Sponge.getServer().getOnlinePlayers().size()).toString())
                         .replace("%maxplayers%", Integer.valueOf(Sponge.getServer().getMaxPlayers()).toString())
                         .replace("%tps%", Long.valueOf(Math.round(Sponge.getServer().getTicksPerSecond())).toString())
-                        .replace("%hoursonline%", Long.valueOf(ManagementFactory.getRuntimeMXBean().getUptime() / 3600000).toString())
-                        .replace("%minutesonline%", Long.valueOf(ManagementFactory.getRuntimeMXBean().getUptime() / 60000).toString());
+                        .replace("%daysonline%", Long.valueOf(ManagementFactory.getRuntimeMXBean().getUptime() / (24 * 3600 * 1000)).toString())
+                        .replace("%hoursonline%", Long.valueOf(ManagementFactory.getRuntimeMXBean().getUptime() % (24 * 3600 * 1000)).toString())
+                        .replace("%minutesonline%", Long.valueOf(ManagementFactory.getRuntimeMXBean().getUptime() % (3600 * 1000)).toString());
 
                 try {
 

--- a/src/main/java/com/magitechserver/magibridge/util/TopicUpdater.java
+++ b/src/main/java/com/magitechserver/magibridge/util/TopicUpdater.java
@@ -22,9 +22,9 @@ public class TopicUpdater extends Thread {
                         .replace("%players%", Integer.valueOf(Sponge.getServer().getOnlinePlayers().size()).toString())
                         .replace("%maxplayers%", Integer.valueOf(Sponge.getServer().getMaxPlayers()).toString())
                         .replace("%tps%", Long.valueOf(Math.round(Sponge.getServer().getTicksPerSecond())).toString())
-                        .replace("%daysonline%", Long.valueOf(ManagementFactory.getRuntimeMXBean().getUptime() / (24 * 3600 * 1000)).toString())
-                        .replace("%hoursonline%", Long.valueOf(ManagementFactory.getRuntimeMXBean().getUptime() % (24 * 3600 * 1000)).toString())
-                        .replace("%minutesonline%", Long.valueOf(ManagementFactory.getRuntimeMXBean().getUptime() % (3600 * 1000)).toString());
+                        .replace("%daysonline%", Long.valueOf(ManagementFactory.getRuntimeMXBean().getUptime() / (24 * 60 * 60 * 1000)).toString())
+                        .replace("%hoursonline%", Long.valueOf((ManagementFactory.getRuntimeMXBean().getUptime() / (60 * 60 * 1000)) % 24).toString())
+                        .replace("%minutesonline%", Long.valueOf((ManagementFactory.getRuntimeMXBean().getUptime() / (60 * 1000)) % 60).toString());
 
                 try {
 


### PR DESCRIPTION
- %daysonline% added
- %hoursonline% and %minutesonline% modified to be remainders rather than totals (i.e. minutes maxes out at 59 then resets to 0)
- Default topic uptime format updated to "Server online for %daysonline% days,  %hoursonline% hours and %minutesonline% minutes!"
