### PR TITLE
Add VERY basic functionality for Discord -> Vanilla Chat

### DIFF
--- a/src/main/java/com/magitechserver/magibridge/VanillaHandler.java
+++ b/src/main/java/com/magitechserver/magibridge/VanillaHandler.java
@@ -1,24 +1,12 @@
 package com.magitechserver.magibridge;
 
-import com.magitechserver.magibridge.config.categories.Messages;
 import com.magitechserver.magibridge.util.FormatType;
 import com.magitechserver.magibridge.util.ReplacerUtil;
-import flavor.pie.boop.BoopableChannel;
-import io.github.nucleuspowered.nucleus.api.NucleusAPI;
-import net.dv8tion.jda.core.entities.Message;
 import org.spongepowered.api.Sponge;
-import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.text.Text;
-import org.spongepowered.api.text.action.TextActions;
 import org.spongepowered.api.text.channel.MessageChannel;
-import org.spongepowered.api.text.format.TextColors;
-import org.spongepowered.api.text.serializer.TextSerializers;
 
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * Created by Daniel Widrick on 07/02/2018.

--- a/src/main/java/com/magitechserver/magibridge/VanillaHandler.java
+++ b/src/main/java/com/magitechserver/magibridge/VanillaHandler.java
@@ -1,0 +1,43 @@
+package com.magitechserver.magibridge;
+
+import com.magitechserver.magibridge.config.categories.Messages;
+import com.magitechserver.magibridge.util.FormatType;
+import com.magitechserver.magibridge.util.ReplacerUtil;
+import flavor.pie.boop.BoopableChannel;
+import io.github.nucleuspowered.nucleus.api.NucleusAPI;
+import net.dv8tion.jda.core.entities.Message;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.action.TextActions;
+import org.spongepowered.api.text.channel.MessageChannel;
+import org.spongepowered.api.text.format.TextColors;
+import org.spongepowered.api.text.serializer.TextSerializers;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Created by Daniel Widrick on 07/02/2018.
+ */
+ 
+ public class VanillaHandler
+ {
+	 
+	 public static void handle(boolean isStaffChannel, FormatType format, Map<String, String> placeholders)
+	 {
+		 MessageChannel messageChannel = Sponge.getServer().getBroadcastChannel();
+		 
+		 String msg = ReplacerUtil.replaceEach(format.get(), placeholders);
+		 if(messageChannel != null)
+		 {
+			 Text messageAsText = ReplacerUtil.toText(msg);
+			 messageChannel.send(messageAsText);
+			 
+			 
+		 }
+	 }
+ }

--- a/src/main/java/com/magitechserver/magibridge/discord/MessageListener.java
+++ b/src/main/java/com/magitechserver/magibridge/discord/MessageListener.java
@@ -4,6 +4,7 @@ import com.magitechserver.magibridge.DiscordHandler;
 import com.magitechserver.magibridge.MagiBridge;
 import com.magitechserver.magibridge.NucleusHandler;
 import com.magitechserver.magibridge.UCHandler;
+import com.magitechserver.magibridge.VanillaHandler;
 import com.magitechserver.magibridge.events.MBMessageEvent;
 import com.magitechserver.magibridge.util.FormatType;
 import com.magitechserver.magibridge.util.ReplacerUtil;
@@ -95,6 +96,13 @@ public class MessageListener extends ListenerAdapter {
             boolean isStaffChannel = channelID.equals(MagiBridge.getConfig().CHANNELS.NUCLEUS.STAFF_CHANNEL);
             NucleusHandler.handle(isStaffChannel, format, placeholders, hasAttachment, e.getMessage().getAttachments());
         }
+		
+		//Use Vanilla Chat
+		if (!MagiBridge.getConfig().CHANNELS.USE_NUCLEUS && !MagiBridge.getConfig().CHANNELS.USE_UCHAT) {
+			FormatType format = FormatType.DISCORD_TO_SERVER_FORMAT;
+			boolean isStaffChannel = channelID.equals(MagiBridge.getConfig().CHANNELS.NUCLEUS.STAFF_CHANNEL);
+			VanillaHandler.handle(isStaffChannel,format,placeholders);
+		}
     }
 
     private boolean isListenableChannel(String channel) {


### PR DESCRIPTION
I had the same issue as #125 . Could not send from discord to server using vanilla chat. I didn't want to mess about with chat plugins so I added a vanillaChatHandler.

It has VERY basic functionality and is missing the features of the other two handlers, but it appears to get message from Discord to Minecraft.