### PR TITLE
@everyone/@here substitution instead of deletion

### DIFF
--- a/src/main/java/com/magitechserver/magibridge/discord/DiscordMessageBuilder.java
+++ b/src/main/java/com/magitechserver/magibridge/discord/DiscordMessageBuilder.java
@@ -126,16 +126,11 @@ public class DiscordMessageBuilder implements MessageBuilder {
             }
         }
 
-        if (!this.allowEveryone) {
-            while(message.matches(".*@everyone.*")) {
-                message = message.replace("@everyone", "");
-            }
-        }
-        if (!this.allowHere) {
-            while(message.matches(".*@here.*")) {
-                message = message.replace("@here", "");
-            }
-        }
+        if(!this.allowEveryone)
+            message.replace("@everyone", "@\u0435veryone");
+
+        if(!this.allowHere)
+            message.replace("@here", "@h\u0435re");
 
         if (message.isEmpty()) return;
 


### PR DESCRIPTION
This solution, compared to the one introduced in #139, properly removes the risk from strings such as `@@hereeveryone`, and other similar strings.

The problem with the previous solution, given the above string, is that it would strip `@everyone`, leaving you with `@@hereeveryone`, then strip `@here` from `@@hereeveryone`, eventually leaving you with `@everyone` - which is not what was intended.

By instead substiuting the character "e" with U+0435 (CYRILLIC SMALL LETTER IE), it can look-alike to the original message in the discord chat while eliminating the problem.

This solution has been tested extensively on my discord server.