### PR TITLE
HelpOP fix and small additions to customization

### DIFF
--- a/src/main/java/com/magitechserver/magibridge/chat/ServerMessageBuilder.java
+++ b/src/main/java/com/magitechserver/magibridge/chat/ServerMessageBuilder.java
@@ -138,14 +138,25 @@ public class ServerMessageBuilder implements MessageBuilder {
             }
 
             Text text = Text.of(prefix, Utils.toText(Utils.replaceEach(rawFormat, this.placeholders)), attachment);
-            chatChannel.sendMessage(Sponge.getServer().getConsole(), text, true);
-        } else if (config.CHANNELS.USE_NUCLEUS && Sponge.getPluginManager().isLoaded("nucleus")) {
+
+            if (config.CORE.ENABLE_CHAT_RELAY) {
+                chatChannel.sendMessage(Sponge.getServer().getConsole(), text, true);
+            }
+        }
+
+        else if (config.CHANNELS.USE_NUCLEUS && Sponge.getPluginManager().isLoaded("nucleus")) {
             MessageChannel messageChannel;
             if (!this.staff) {
-                if (Sponge.getPluginManager().getPlugin("boop").isPresent() && config.CORE.USE_BOOP) {
-                    messageChannel = new BoopableChannel(MessageChannel.TO_ALL);
-                } else {
-                    messageChannel = MessageChannel.TO_ALL;
+                // probably could be done more accurate
+                if (config.CORE.ENABLE_CHAT_RELAY) {
+                    if (Sponge.getPluginManager().getPlugin("boop").isPresent() && config.CORE.USE_BOOP) {
+                        messageChannel = new BoopableChannel(MessageChannel.TO_ALL);
+                    } else {
+                        messageChannel = MessageChannel.TO_ALL;
+                    }
+                }
+                else {
+                    return;
                 }
             } else {
                 this.format = FormatType.DISCORD_TO_SERVER_STAFF_FORMAT;
@@ -153,12 +164,16 @@ public class ServerMessageBuilder implements MessageBuilder {
             }
 
             messageChannel.send(Text.of(prefix, Utils.toText(this.format.format(this.placeholders)), attachment));
-        } else {
+        }
+
+        else {
             MessageChannel messageChannel = Sponge.getPluginManager().getPlugin("boop").isPresent() ?
                     new BoopableChannel(MessageChannel.TO_ALL) :
                     MessageChannel.TO_ALL;
 
-            messageChannel.send(Text.of(prefix, Utils.toText(this.format.format(this.placeholders)), attachment));
+            if (config.CORE.ENABLE_CHAT_RELAY) {
+                messageChannel.send(Text.of(prefix, Utils.toText(this.format.format(this.placeholders)), attachment));
+            }
         }
     }
 

--- a/src/main/java/com/magitechserver/magibridge/config/categories/Channel.java
+++ b/src/main/java/com/magitechserver/magibridge/config/categories/Channel.java
@@ -24,6 +24,8 @@ public class Channel {
     public String LIST_COMMAND = "!online";
     @Setting(value = "delete-list-message", comment = "Should MagiBridge delete the player list message?")
     public boolean DELETE_LIST = true;
+    @Setting(value = "list-delay", comment = "Delay to delete list message. Make sure delete-list-message is true!")
+    public int LIST_DELAY = 10;
     @Setting(value = "console-command", comment = "Discord command that executes server console commands")
     public String CONSOLE_COMMAND = "!cmd";
     @Setting(value = "commands-role-override", comment = "If a command is defined here, it will ONLY run if the user has the defined role.\n" +

--- a/src/main/java/com/magitechserver/magibridge/config/categories/CoreCategory.java
+++ b/src/main/java/com/magitechserver/magibridge/config/categories/CoreCategory.java
@@ -22,6 +22,8 @@ public class CoreCategory {
     @Setting(value = "cut-messages", comment = "Set to false if MagiBridge should NOT cut messages coming from Discord with more than\n" +
             "120 characters. This can turn the chat ugly if someone sends a big message")
     public boolean CUT_MESSAGES = false;
+    @Setting(value = "send-from-discord-to-server", comment = "Set to false if you don't want to relay common chat messages from Discord to game")
+    public boolean ENABLE_CHAT_RELAY = true;
     @Setting(value = "topic-updater-interval", comment = "Topic Updater interval in minutes, minimum is 5. If you're having rate limit errors, set this to 10 or higher!")
     public int UPDATER_INTERVAL = 10;
     @Setting(value = "enable-topic-updater", comment = "Should MagiBridge enable the Topic Updater, updating the topic of the main Discord channel?")

--- a/src/main/java/com/magitechserver/magibridge/config/categories/Messages.java
+++ b/src/main/java/com/magitechserver/magibridge/config/categories/Messages.java
@@ -16,6 +16,8 @@ public class Messages {
     @Setting(value = "no-players-message", comment = "Message shown when there are no players in the server \n" +
             "and the list command is executed")
     public String NO_PLAYERS = "**There are no players online!**";
+    @Setting(value = "list-format", comment = "Text shown before numbers (current and max online) using list command,")
+    public String LIST_TEXT = "Players online";
     @Setting(value = "console-command-no-permisson", comment = "No permission message (for console command)")
     public String CONSOLE_NO_PERMISSION = "**You don't have permission to use this command!**";
     @Setting(value = "server-to-discord-format", comment = "Format of messages sent FROM the server TO discord")

--- a/src/main/java/com/magitechserver/magibridge/discord/MessageListener.java
+++ b/src/main/java/com/magitechserver/magibridge/discord/MessageListener.java
@@ -67,7 +67,7 @@ public class MessageListener extends ListenerAdapter {
 
         // Handle player list command
         if (message.equalsIgnoreCase(config.CHANNELS.LIST_COMMAND)) {
-            Utils.dispatchList(e.getChannel());
+            Utils.dispatchList(e.getChannel(), e.getMessage());
             return;
         }
 

--- a/src/main/java/com/magitechserver/magibridge/events/DiscordMessageEvent.java
+++ b/src/main/java/com/magitechserver/magibridge/events/DiscordMessageEvent.java
@@ -10,7 +10,7 @@ import org.spongepowered.api.event.impl.AbstractEvent;
  * An event that is thrown when a message is received or sent from Discord to Server
  * or vice-versa.
  */
-public class DiscordMessageEvent extends AbstractEvent implements  Cancellable {
+public class DiscordMessageEvent extends AbstractEvent implements Cancellable {
 
     private boolean cancelled = false;
     private MessageBuilder messageBuilder;

--- a/src/main/java/com/magitechserver/magibridge/listeners/NucleusListeners.java
+++ b/src/main/java/com/magitechserver/magibridge/listeners/NucleusListeners.java
@@ -53,6 +53,7 @@ public class NucleusListeners {
 
             DiscordMessageBuilder.forChannel(channel)
                     .placeholders(Utils.playerPlaceholders(player))
+                    .placeholder("message", event.getArguments())
                     .format(format)
                     .allowEveryone(player.hasPermission("magibridge.everyone"))
                     .allowMentions(player.hasPermission("magibridge.mention"))

--- a/src/main/java/com/magitechserver/magibridge/util/Utils.java
+++ b/src/main/java/com/magitechserver/magibridge/util/Utils.java
@@ -5,6 +5,7 @@ import com.magitechserver.magibridge.config.categories.Channel;
 import com.magitechserver.magibridge.config.categories.ConfigCategory;
 import io.github.nucleuspowered.nucleus.api.NucleusAPI;
 import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageChannel;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import org.spongepowered.api.Sponge;
@@ -74,9 +75,10 @@ public class Utils {
                 cmd);
     }
 
-    public static void dispatchList(MessageChannel channel) {
+    public static void dispatchList(MessageChannel channel, Message originalMessage) {
         ConfigCategory config = MagiBridge.getInstance().getConfig();
         boolean shouldDelete = config.CHANNELS.DELETE_LIST;
+        int delay = config.CHANNELS.LIST_DELAY;
 
         List<Player> onlinePlayers = Sponge.getServer().getOnlinePlayers().stream()
                 .filter(p -> !p.get(Keys.VANISH).orElse(false))
@@ -92,13 +94,14 @@ public class Utils {
                             .replace("%prefix%", p.getOption("prefix").orElse("")))
                     .collect(Collectors.joining(", "));
 
-            message = "**Players online (" + onlinePlayers.size() + "/" + Sponge.getServer().getMaxPlayers() + "):** "
+            message = "**"+ config.MESSAGES.LIST_TEXT + " (" + onlinePlayers.size() + "/" + Sponge.getServer().getMaxPlayers() + "):** "
                     + "```" + players + "```";
         }
 
         channel.sendMessage(message).queue(m -> {
             if (shouldDelete) {
-                m.delete().queueAfter(10, TimeUnit.SECONDS);
+                m.delete().queueAfter(delay, TimeUnit.SECONDS);
+                originalMessage.delete().queueAfter(delay, TimeUnit.SECONDS);
             }
         });
     }


### PR DESCRIPTION
1. HelpOP fix, addressing #199.
2. Ability for "lazy" customizing of "Players online" message with !online. Not a real message customization, just this part of text, but suit my need for now.
3. New config variable for ignoring "common" messages (not stuff/helpop) A bit messy, but gets the job done.  Default is enabled so shouldn't affect anyone (in case I'm only one needing it)
4.  If DELETE_LIST is true, deletes not only its own message, but  message with "!online" by player too. Requires discord manage_messages permissions, but its not a big deal as I think, as its open source etc.
5. List deletion delay now configurable. Default is 10, as it is hardcoded now. 