### PR TITLE
Fix bot responding to itself

### DIFF
--- a/src/main/java/com/magitechserver/magibridge/discord/MessageListener.java
+++ b/src/main/java/com/magitechserver/magibridge/discord/MessageListener.java
@@ -26,7 +26,9 @@ public class MessageListener extends ListenerAdapter {
 
     private void process(MessageReceivedEvent e) {
         ConfigCategory config = MagiBridge.getInstance().getConfig();
-
+        if (e.getAuthor().getId().equals(e.getJDA().getSelfUser().getId())) {
+            return;
+        }
         if (e.getAuthor().getId().equals(e.getJDA().getSelfUser().getId()) ||
                 e.getAuthor().isFake() ||
                 e.getAuthor().isBot()) {


### PR DESCRIPTION
When enabling support to read messages by other bots, the bot also enables reading messages from itself. This results in infinite recursive calls attempting to run commands to the console. This small patch should fix it.